### PR TITLE
A page to list tor enodes

### DIFF
--- a/app.js
+++ b/app.js
@@ -270,7 +270,12 @@ api.on('connection', function (spark)
 	spark.on('enode', function (data) {
 		console.success('API', 'EN', 'Enode from:', data.id);
 		app.enodes[data.id] = data.enode;
-	  });
+  });
+
+	spark.on('tor-enode', function (data) {
+		console.success('API', 'EN', 'Tor enode from:', data.id);
+		app.tor_enodes[data.id] = data.enode;
+  });
 
 	spark.on('history', function (data)
 	{

--- a/lib/express.js
+++ b/lib/express.js
@@ -5,6 +5,7 @@ var bodyParser = require('body-parser');
 var fs = require('fs');
 
 app.enodes = {}
+app.tor_enodes = {}
 
 // view engine setup
 app.set('views', path.join(__dirname, (process.env.LITE === 'true' ? '../src-lite/views' : '../src/views')));
@@ -19,6 +20,10 @@ app.get('/', function(req, res) {
 
 app.get('/static-nodes.json', function(req, res) {
 	res.send(JSON.stringify(Object.values(app.enodes)));
+});
+
+app.get('/static-nodes-tor.json', function(req, res) {
+	res.send(JSON.stringify(Object.values(app.tor_enodes)));
 });
 
 // catch 404 and forward to error handler


### PR DESCRIPTION
Similarly to `/static-nodes.json` provide an endpoint `/static-nodes-tor.json` where enodes published on the `tor-enode` topic are listed. Goes together with https://github.com/ShyftNetwork/shyft_nethermind_poa_aura_testnet/commit/3e0844303d200f624f2435dd1a9737c6d52787da